### PR TITLE
Decouple excel resource from the TYPO3 extension

### DIFF
--- a/Classes/Service/Resources/Excel.php
+++ b/Classes/Service/Resources/Excel.php
@@ -63,8 +63,8 @@ class Excel extends AbstractResource implements ResourceInterface
     {
         $configuration = $this->getConfiguration();
 
-        if (!ExtensionManagementUtility::isLoaded('phpexcel_library')) {
-            throw new \Exception('phpexcel_library is not loaded', 12367812368);
+        if (!class_exists(\PHPExcel_IOFactory::class)) {
+            throw new \Exception('PHP Excel is needed! Please install EXT:phpexcel_library (regular mode) or phpoffice/phpexcel (composer mode)', 12367812368);
         }
 
         $filename = GeneralUtility::getFileAbsFileName($this->filepath);

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
     "php": ">=5.5.0",
     "typo3/cms-core": "~6.2.0||~7.6.0||~8.6.0||~8.7.0||dev-master"
   },
+  "suggest": {
+    "phpoffice/phpexcel": "Use Excel files as import resource"
+  },
   "replace": {
     "importr": "self.version",
     "typo3-ter/importr": "self.version"


### PR DESCRIPTION
So the user has the option to install the TYPO3 extension or to use "phpoffice/phpexcel" as composer package directly.