### PR TITLE
Do not push FlashMessages to sessions in command controller

### DIFF
--- a/Classes/Command/ImportCommandController.php
+++ b/Classes/Command/ImportCommandController.php
@@ -70,8 +70,7 @@ class ImportCommandController extends Command
             FlashMessage::class,
             '',
             'Initializing ServiceManager',
-            FlashMessage::INFO,
-            true
+            FlashMessage::INFO
         );
         $this->addFlashMessage($message);
 


### PR DESCRIPTION
This fix avoid the Core Exception:
```
Argument 1 passed to TYPO3\CMS\Core\Session\Backend\DatabaseSessionBackend::update() must be of the type string, null given, called in /.../typo3/sysext/core/Classes/Authentication/AbstractUserAuthentication.php on line 1289      
```

The reason was: The CommandController try to store a FlashMessage into the user Session. but in the CLI context there is no session backend, because there is no valid user.