### PR TITLE
Fix TYPO3 breaking changes

### DIFF
--- a/Classes/Domain/Model/Strategy.php
+++ b/Classes/Domain/Model/Strategy.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace HDNET\Importr\Domain\Model;
 
 use Symfony\Component\Yaml\Yaml;
+use TYPO3\CMS\Core\LinkHandling\Exception\UnknownUrnException;
 use TYPO3\CMS\Core\LinkHandling\LinkService;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 /**
@@ -172,14 +174,16 @@ class Strategy extends AbstractEntity
             return '';
         }
 
-        if (GeneralUtility::compat_version('8.7')) {
+        try {
             $service = new LinkService();
             $data = $service->resolveByStringRepresentation($path);
             if ($data['file'] instanceof FileInterface) {
                 return $data['file']->getForLocalProcessing(false);
+            } else {
+                return GeneralUtility::getFileAbsFileName($path);
             }
+        } catch (UnknownUrnException $e) {
+            return GeneralUtility::getFileAbsFileName($path);
         }
-
-        return GeneralUtility::getFileAbsFileName($path);
     }
 }

--- a/Classes/Service/FileService.php
+++ b/Classes/Service/FileService.php
@@ -13,12 +13,10 @@ class FileService
 {
     /**
      * @param string $filename
-     * @param bool   $onlyRelative
-     * @param bool   $relToTYPO3_mainDir
      * @return string
      */
-    public function getFileAbsFileName($filename, $onlyRelative = true, $relToTYPO3_mainDir = false)
+    public function getFileAbsFileName($filename)
     {
-        return GeneralUtility::getFileAbsFileName($filename, $onlyRelative, $relToTYPO3_mainDir);
+        return GeneralUtility::getFileAbsFileName($filename);
     }
 }


### PR DESCRIPTION
GetFileAbsFileName() is only used with one argument anyway and in TYPO3 the two other arguments got removed.
Moreover, compact_version was removed. If just removed the condition because the extension requires TYPO3 10, I could also add a version check if necessary.
Feedback is appreciated :)  